### PR TITLE
feat/mongodb: add apt key for 3.2 version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ mongodb_package_state: present
 mongodb_version: "4.0"
 mongodb_apt_keyserver: keyserver.ubuntu.com
 mongodb_apt_key_id:
+  "3.2": "42F3E95A2C4F08279C4960ADD68FA50FEA312927"
   "3.4": "0C49F3730359A14518585931BC711F9BA15703C6"
   "3.6": "2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5"
   "4.0": "9DA31620334BD75D9DCB49F368818C72E52529D4"


### PR DESCRIPTION
feat/mongodb: add apt key for 3.2 version